### PR TITLE
폰트 오류 해결

### DIFF
--- a/InFrame/Info.plist
+++ b/InFrame/Info.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>UIAppFonts</key>
 	<array>
-		<string>CarterOne-Regular</string>
+		<string>CarterOne-Regular.ttf</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>


### PR DESCRIPTION
`Info.plist`에서 폰트 파일의 확장자를 적어주지 않아 폰트가 적용되지 않았습니다. 🙇‍♀️
### 한 일
- 테스트 후 적용 확인

#### `CarterOne`이라는 이름으로 사용할 수 있습니다.